### PR TITLE
fix: Customizable nVidia driver package name

### DIFF
--- a/roles/nvidia_drivers/defaults/main.yml
+++ b/roles/nvidia_drivers/defaults/main.yml
@@ -1,1 +1,2 @@
+nvidia_drivers_driver_package_name: nvidia-driver
 nvidia_drivers_install_containers: false

--- a/roles/nvidia_drivers/tasks/drivers.yml
+++ b/roles/nvidia_drivers/tasks/drivers.yml
@@ -39,11 +39,10 @@
   # This package conflicts with the native pve-firmware package, so skip this step if it's installed
   when: "'pve-firmware' not in ansible_facts.packages"
 
-- name: Install nVidia driver packages
+- name: Install general nVidia driver packages
   notify: Reboot machine
   ansible.builtin.package:
     name:
       - nvidia-detect
-      - nvidia-driver
-      - nvidia-tesla-driver
+      - "{{ nvidia_drivers_driver_package_name }}"
     state: present


### PR DESCRIPTION
Not all nVidia GPUs are covered by the current nvidia-driver package therefore making the package configurable per node